### PR TITLE
Feat: Export cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "promkit-derive",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ promkit = { version = "0.9", features = ["all"] }
 promkit-derive = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "rustls-tls", "system-proxy"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.15"
 tracing = "0.1.41"

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
     println!("{}", "Logging out...".yellow().italic());
     match client.logout().await {
         Ok(_) => println!("{}", "Logged out".italic().green()),
-        Err(e) => eprintln!("{} {}", "Error logging out:".italic().red(), e)
+        Err(e) => eprintln!("{} {}", "Error logging out:".italic().red(), e),
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use matrix_sdk::ruma::presence::PresenceState;
 use promkit::crossterm::style::Stylize;
 use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
+use utils::cache::user_cache::ExportCache;
 
 // Keeping this for later as a reminder.
 // (force shutdown)
@@ -86,11 +87,20 @@ async fn main() -> anyhow::Result<()> {
         }
 
         let selected_rooms = prompts::select_room(&main_client).await?;
+        // (note) export data cache for all rooms.
+        // it has to be added here and cloned into the export tasks.
+        // the clones all point to the same `Arc<Mutex>`.
+        let cache = ExportCache::import_cache();
 
         let mut export_tasks = JoinSet::new();
         for room_id in selected_rooms {
+            let ref_cache = cache.clone();
             let room = main_client.get_room(&room_id).unwrap();
-            export_tasks.spawn(async move { utils::export::export_room(room).await });
+
+            #[rustfmt::skip]
+            export_tasks.spawn(async move {
+                utils::export::export_room(room, ref_cache).await
+            });
         }
 
         loop {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,3 @@
+pub mod cache;
 pub mod client;
 pub mod export;
-pub mod cache;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod export;
+pub mod cache;

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,9 +1,13 @@
 use std::{io::stdout, sync::Arc};
 
 use matrix_sdk::ruma::OwnedRoomId;
-use promkit::crossterm::{cursor, style::Stylize, ExecutableCommand};
+use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 use serde::{Deserialize, Serialize};
-use tokio::{fs::File, io::{AsyncWriteExt, BufWriter}, sync::mpsc::Receiver};
+use tokio::{
+    fs::File,
+    io::{AsyncWriteExt, BufWriter},
+    sync::mpsc::Receiver,
+};
 
 /// The "interval" for caching data.
 ///
@@ -26,7 +30,7 @@ const CACHE_FILE: &'static str = "met-cache.json";
 ///
 /// On larger exports, this cache gets created, and written to a file.
 /// The token here is of the last fetched message chunk.
-/// 
+///
 /// When the program runs again, this is imported (deserialized), and the export function
 /// continues from `last_token`, instead of starting over.
 #[derive(Clone, Serialize, Deserialize)]
@@ -34,14 +38,14 @@ pub struct RoomExportCache {
     /// Collection of room IDs
     room_id: Option<OwnedRoomId>,
     /// Collection of pagination tokens
-    last_token: Option<String>
+    last_token: Option<String>,
 }
 
 /// The final export cache. This is a collection of [`RoomExportCache`]s that can be exported to a
 /// file.
 #[derive(Clone, Serialize, Deserialize)]
 struct ExportCache {
-    inner: Vec<RoomExportCache>
+    inner: Vec<RoomExportCache>,
 }
 
 impl RoomExportCache {
@@ -49,7 +53,7 @@ impl RoomExportCache {
     pub fn new() -> Self {
         Self {
             room_id: None,
-            last_token: None
+            last_token: None,
         }
     }
 
@@ -114,15 +118,16 @@ impl RoomExportCache {
                     println!(
                         "{}\n{} {}\n{}",
                         "Cache file couldn't be recovered.".red(),
-                        "Reason:".white().bold(), e,
+                        "Reason:".white().bold(),
+                        e,
                         "Making a new cache in memory instead.".white()
                     );
-                    return Self::default()
+                    return Self::default();
                 }
             }
         } else {
             println!("{}", "Cache file not found, making a new one.".white());
-            return Self::default()
+            return Self::default();
         }
     }
 }

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,0 +1,111 @@
+use std::{io::stdout, sync::Arc};
+
+use matrix_sdk::ruma::OwnedRoomId;
+use promkit::crossterm::{cursor, ExecutableCommand};
+use serde::{Deserialize, Serialize};
+use tokio::{fs::File, io::{AsyncWriteExt, BufWriter}, sync::mpsc::Receiver};
+
+/// The "interval" for caching data.
+///
+/// This is not represented as a time interval, but a denominator for the current amount of chunks.
+/// For example, see [`utils::export::fetch_chunks`]:
+///
+/// ```
+/// if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
+///     cache_tx.send(token.clone()).await?;
+/// }
+/// ```
+///
+/// Since 1 chunk = 100 messages, this will run the cache every 10.000 messages.
+pub const CACHE_INTERVAL: u64 = 100;
+
+/// File name for the cache.
+const CACHE_FILE: &'static str = "met-cache.json";
+
+/// Main struct for cache data
+///
+/// On larger exports, this cache gets created, and written to a file.
+/// The token here is of the last fetched message chunk.
+/// 
+/// When the program runs again, this is imported (deserialized), and the export function
+/// continues from `last_token`, instead of starting over.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RoomExportCache {
+    /// Collection of room IDs
+    room_id: Option<OwnedRoomId>,
+    /// Collection of pagination tokens
+    last_token: Option<String>
+}
+
+/// The final export cache. This is a collection of [`RoomExportCache`]s that can be exported to a
+/// file.
+#[derive(Clone, Serialize, Deserialize)]
+struct ExportCache {
+    inner: Vec<RoomExportCache>
+}
+
+impl RoomExportCache {
+    // Create a new, empty export cache.
+    pub fn new() -> Self {
+        Self {
+            room_id: None,
+            last_token: None
+        }
+    }
+
+    pub fn last_token(&self) -> Option<&String> {
+        self.last_token.as_ref()
+    }
+
+    /// Add room data to the cache.
+    pub fn add_room_data(&mut self, room_id: OwnedRoomId, last_token: Option<String>) {
+        self.room_id.replace(room_id);
+        if let Some(token) = last_token {
+            self.last_token.replace(token);
+        }
+    }
+
+    /// Update the token of this room through a channel
+    ///
+    /// This should be used inside a background task.
+    pub async fn update_token(&mut self, mut new_token: Receiver<String>) -> anyhow::Result<()> {
+        while let Some(new_token) = new_token.recv().await {
+            stdout().execute(cursor::MoveDown(2))?;
+            println!("(cache) Saving token {}", new_token);
+
+            stdout().execute(cursor::RestorePosition)?;
+
+            self.last_token.replace(new_token);
+            self.write_cache().await?;
+        }
+
+        anyhow::Ok(())
+    }
+
+    /// Writes [`self`] to the cache file as json.
+    async fn write_cache(&self) -> anyhow::Result<()> {
+        let mut cache_file = File::create(CACHE_FILE).await?;
+
+        let serialized = serde_json::to_string(&self).unwrap();
+
+        cache_file.write(serialized.as_bytes()).await?;
+        cache_file.flush().await?;
+
+        anyhow::Ok(())
+    }
+
+    /// Import the cache from a file.
+    ///
+    /// This is synchronous, as it is used before starting any downloads.
+    ///
+    /// If the file is not found or invalid, a new one is made.
+    pub fn import_cache() -> anyhow::Result<Self> {
+        let cache_file: Vec<u8> = std::fs::read(CACHE_FILE)?;
+
+        if let Ok(result) = serde_json::from_slice::<Self>(&*cache_file) {
+            return anyhow::Ok(result);
+        } else {
+            return anyhow::Ok(Self::new());
+        }
+    }
+}

--- a/src/utils/cache.rs
+++ b/src/utils/cache.rs
@@ -1,7 +1,7 @@
 use std::{io::stdout, sync::Arc};
 
 use matrix_sdk::ruma::OwnedRoomId;
-use promkit::crossterm::{cursor, ExecutableCommand};
+use promkit::crossterm::{cursor, style::Stylize, ExecutableCommand};
 use serde::{Deserialize, Serialize};
 use tokio::{fs::File, io::{AsyncWriteExt, BufWriter}, sync::mpsc::Receiver};
 
@@ -45,7 +45,7 @@ struct ExportCache {
 }
 
 impl RoomExportCache {
-    // Create a new, empty export cache.
+    /// Create a new, empty export cache.
     pub fn new() -> Self {
         Self {
             room_id: None,
@@ -98,14 +98,37 @@ impl RoomExportCache {
     ///
     /// This is synchronous, as it is used before starting any downloads.
     ///
-    /// If the file is not found or invalid, a new one is made.
-    pub fn import_cache() -> anyhow::Result<Self> {
-        let cache_file: Vec<u8> = std::fs::read(CACHE_FILE)?;
+    /// If the file is not found OR is invalid, a new cache is made.
+    pub fn import_cache() -> Self {
+        let file = std::fs::read_to_string(CACHE_FILE);
 
-        if let Ok(result) = serde_json::from_slice::<Self>(&*cache_file) {
-            return anyhow::Ok(result);
+        if let Ok(file) = file {
+            println!("{}", "Cache file found, recovering...".yellow());
+
+            match serde_json::from_str::<Self>(&file) {
+                Ok(cache) => {
+                    println!("{}", "Cache file recovered.".green());
+                    return cache;
+                }
+                Err(e) => {
+                    println!(
+                        "{}\n{} {}\n{}",
+                        "Cache file couldn't be recovered.".red(),
+                        "Reason:".white().bold(), e,
+                        "Making a new cache in memory instead.".white()
+                    );
+                    return Self::default()
+                }
+            }
         } else {
-            return anyhow::Ok(Self::new());
+            println!("{}", "Cache file not found, making a new one.".white());
+            return Self::default()
         }
+    }
+}
+
+impl Default for RoomExportCache {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/utils/cache/mod.rs
+++ b/src/utils/cache/mod.rs
@@ -1,0 +1,2 @@
+pub mod user_cache;
+pub mod output_cache;

--- a/src/utils/cache/mod.rs
+++ b/src/utils/cache/mod.rs
@@ -1,2 +1,2 @@
-pub mod user_cache;
 pub mod output_cache;
+pub mod user_cache;

--- a/src/utils/cache/mod.rs
+++ b/src/utils/cache/mod.rs
@@ -1,2 +1,16 @@
 pub mod output_cache;
 pub mod user_cache;
+
+/// The "interval" for caching data.
+///
+/// This is not represented as a time interval, but a denominator for the current amount of chunks.
+/// For example, see [`utils::export::fetch_chunks`]:
+///
+/// ```
+/// if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
+///     cache_tx.send(token.clone()).await?;
+/// }
+/// ```
+///
+/// Since 1 chunk = 100 messages, this will run the cache every 10.000 messages.
+pub const CACHE_INTERVAL: u64 = 100;

--- a/src/utils/cache/output_cache.rs
+++ b/src/utils/cache/output_cache.rs
@@ -1,0 +1,81 @@
+use std::io::stdout;
+
+use matrix_sdk::{
+    deserialized_responses::{TimelineEvent, TimelineEventKind},
+    ruma::events::{MessageLikeEvent, room::message::RoomMessageEvent},
+};
+use promkit::crossterm::{ExecutableCommand, cursor};
+use tokio::{fs::OpenOptions, io::AsyncWriteExt, sync::mpsc::Receiver};
+
+//#[derive(Clone)]
+pub struct FileCache {
+    user: String,
+    messages: Vec<TimelineEvent>,
+}
+
+impl FileCache {
+    pub fn new(user: String) -> Self {
+        Self {
+            user,
+            messages: Vec::new(),
+        }
+    }
+
+    pub async fn update_messages(
+        &mut self,
+        mut msg_rx: Receiver<Vec<TimelineEvent>>,
+        mut write_rx: Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        let mut buf_events = 0;
+
+        while let Some(mut new_events) = msg_rx.recv().await {
+            buf_events += &new_events.len();
+            stdout().execute(cursor::MoveDown(3))?;
+            println!("(cache) Caching {} messages", buf_events);
+            stdout().execute(cursor::RestorePosition)?;
+
+            self.messages.append(&mut new_events);
+
+            if let Ok(_) = write_rx.try_recv() {
+                buf_events = 0;
+                self.write_to_file().await?;
+            }
+        }
+
+        anyhow::Ok(())
+    }
+
+    async fn write_to_file(&mut self) -> anyhow::Result<()> {
+        let mut out_file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(format!("{}-export.txt", self.user))
+            .await?;
+
+        let mut messages = Vec::new();
+        std::mem::swap(&mut messages, &mut self.messages);
+
+        // At first I thought this is gonna be bad and slow
+        // turns out it's fine.
+        let string: String = messages.into_iter().map(|ev| {
+            if let TimelineEventKind::Decrypted(de) = &ev.kind
+                && let Ok(MessageLikeEvent::Original(orig)) =
+                    de.event.deserialize_as::<RoomMessageEvent>()
+            {
+                format!(
+                    "{:?} — {}: {}\n",
+                    orig.origin_server_ts,
+                    orig.sender,
+                    orig.content.body()
+                )
+            } else {
+                format!("Incorrect type.\n")
+            }
+        }).collect();
+
+        out_file.write(string.as_bytes()).await?;
+        out_file.flush().await?;
+
+        anyhow::Ok(())
+    }
+}

--- a/src/utils/cache/output_cache.rs
+++ b/src/utils/cache/output_cache.rs
@@ -57,6 +57,7 @@ impl FileCache {
 
         // At first I thought this is gonna be bad and slow
         // turns out it's fine.
+        // I guess that's coz "With the encryption feature, messages are decrypted if possible" :D
         let string: String = messages
             .into_iter()
             .map(|ev| {

--- a/src/utils/cache/output_cache.rs
+++ b/src/utils/cache/output_cache.rs
@@ -57,21 +57,24 @@ impl FileCache {
 
         // At first I thought this is gonna be bad and slow
         // turns out it's fine.
-        let string: String = messages.into_iter().map(|ev| {
-            if let TimelineEventKind::Decrypted(de) = &ev.kind
-                && let Ok(MessageLikeEvent::Original(orig)) =
-                    de.event.deserialize_as::<RoomMessageEvent>()
-            {
-                format!(
-                    "{:?} — {}: {}\n",
-                    orig.origin_server_ts,
-                    orig.sender,
-                    orig.content.body()
-                )
-            } else {
-                format!("Incorrect type.\n")
-            }
-        }).collect();
+        let string: String = messages
+            .into_iter()
+            .map(|ev| {
+                if let TimelineEventKind::Decrypted(de) = &ev.kind
+                    && let Ok(MessageLikeEvent::Original(orig)) =
+                        de.event.deserialize_as::<RoomMessageEvent>()
+                {
+                    format!(
+                        "{:?} — {}: {}\n",
+                        orig.origin_server_ts,
+                        orig.sender,
+                        orig.content.body()
+                    )
+                } else {
+                    format!("Incorrect type.\n")
+                }
+            })
+            .collect();
 
         out_file.write(string.as_bytes()).await?;
         out_file.flush().await?;

--- a/src/utils/cache/user_cache.rs
+++ b/src/utils/cache/user_cache.rs
@@ -1,11 +1,11 @@
-use std::{io::stdout, sync::Arc};
+use std::io::stdout;
 
 use matrix_sdk::ruma::OwnedRoomId;
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 use serde::{Deserialize, Serialize};
 use tokio::{
     fs::File,
-    io::{AsyncWriteExt, BufWriter},
+    io::AsyncWriteExt,
     sync::mpsc::Receiver,
 };
 

--- a/src/utils/cache/user_cache.rs
+++ b/src/utils/cache/user_cache.rs
@@ -3,11 +3,7 @@ use std::io::stdout;
 use matrix_sdk::ruma::OwnedRoomId;
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 use serde::{Deserialize, Serialize};
-use tokio::{
-    fs::File,
-    io::AsyncWriteExt,
-    sync::mpsc::Receiver,
-};
+use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc::Receiver};
 
 /// The "interval" for caching data.
 ///

--- a/src/utils/cache/user_cache.rs
+++ b/src/utils/cache/user_cache.rs
@@ -1,26 +1,20 @@
-use std::io::stdout;
+use std::{
+    io::{Write, stdout},
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
 
 use matrix_sdk::ruma::OwnedRoomId;
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 use serde::{Deserialize, Serialize};
-use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc::Receiver};
-
-/// The "interval" for caching data.
-///
-/// This is not represented as a time interval, but a denominator for the current amount of chunks.
-/// For example, see [`utils::export::fetch_chunks`]:
-///
-/// ```
-/// if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
-///     cache_tx.send(token.clone()).await?;
-/// }
-/// ```
-///
-/// Since 1 chunk = 100 messages, this will run the cache every 10.000 messages.
-pub const CACHE_INTERVAL: u64 = 100;
+use tokio::sync::mpsc::Receiver;
 
 /// File name for the cache.
 const CACHE_FILE: &'static str = "met-cache.json";
+
+/// A dummy token. If this is set, the export is skipped.
+// FIXME: This should be its own field in the cache. This works for now,
+// but later mby keep the last token, and turn this field to `true`.
+pub const CACHE_DONE: &'static str = "export_completed";
 
 /// Main struct for cache data
 ///
@@ -33,63 +27,74 @@ const CACHE_FILE: &'static str = "met-cache.json";
 pub struct RoomExportCache {
     /// Collection of room IDs
     room_id: Option<OwnedRoomId>,
+
     /// Collection of pagination tokens
     last_token: Option<String>,
+
+    /// Room display name
+    display_name: Option<String>,
 }
 
 /// The final export cache. This is a collection of [`RoomExportCache`]s that can be exported to a
 /// file.
 #[derive(Clone, Serialize, Deserialize)]
-struct ExportCache {
-    inner: Vec<RoomExportCache>,
+pub struct ExportCache {
+    inner: Arc<Mutex<ExportCacheInner>>,
 }
 
-impl RoomExportCache {
-    /// Create a new, empty export cache.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct ExportCacheInner {
+    pub rooms: Vec<RoomExportCache>,
+}
+
+impl ExportCacheInner {
+    fn new() -> Self {
+        let cache = Self { rooms: Vec::new() };
+
+        cache
+    }
+}
+
+impl ExportCache {
     pub fn new() -> Self {
+        let cache = Mutex::new(ExportCacheInner::new());
+
         Self {
-            room_id: None,
-            last_token: None,
+            inner: Arc::new(cache),
         }
     }
 
-    pub fn last_token(&self) -> Option<&String> {
-        self.last_token.as_ref()
+    fn add_room(&self, room: RoomExportCache) {
+        self.inner.lock().unwrap().rooms.push(room);
     }
 
-    /// Add room data to the cache.
-    pub fn add_room_data(&mut self, room_id: OwnedRoomId, last_token: Option<String>) {
-        self.room_id.replace(room_id);
-        if let Some(token) = last_token {
-            self.last_token.replace(token);
-        }
+    /// Replace an older token of `room_id` in the export cache with a new one
+    pub fn update_room_token(&self, room_id: &OwnedRoomId, token: String) -> anyhow::Result<()> {
+        self.inner
+            .lock()
+            .unwrap()
+            .rooms
+            .iter_mut()
+            .find(|room| room.room_id().unwrap() == room_id)
+            .ok_or(anyhow::anyhow!("No room found."))
+            .and_then(|room_cache| room_cache.set_token(token))
     }
 
-    /// Update the token of this room through a channel
-    ///
-    /// This should be used inside a background task.
-    pub async fn update_token(&mut self, mut new_token: Receiver<String>) -> anyhow::Result<()> {
-        while let Some(new_token) = new_token.recv().await {
-            stdout().execute(cursor::MoveDown(2))?;
-            println!("(cache) Saving token {}", new_token);
-
-            stdout().execute(cursor::RestorePosition)?;
-
-            self.last_token.replace(new_token);
-            self.write_cache().await?;
-        }
-
-        anyhow::Ok(())
+    pub fn get_inner(
+        &self,
+    ) -> anyhow::Result<
+        MutexGuard<'_, ExportCacheInner>,
+        PoisonError<MutexGuard<'_, ExportCacheInner>>,
+    > {
+        self.inner.lock()
     }
 
     /// Writes [`self`] to the cache file as json.
-    async fn write_cache(&self) -> anyhow::Result<()> {
-        let mut cache_file = File::create(CACHE_FILE).await?;
+    pub fn write_cache(&self) -> anyhow::Result<()> {
+        let mut cache_file = std::fs::File::create(CACHE_FILE)?;
+        let serialized = serde_json::to_string(self).unwrap();
 
-        let serialized = serde_json::to_string(&self).unwrap();
-
-        cache_file.write(serialized.as_bytes()).await?;
-        cache_file.flush().await?;
+        cache_file.write_all(serialized.as_bytes())?;
 
         anyhow::Ok(())
     }
@@ -118,13 +123,86 @@ impl RoomExportCache {
                         e,
                         "Making a new cache in memory instead.".white()
                     );
-                    return Self::default();
+                    return Self::new();
                 }
             }
         } else {
             println!("{}", "Cache file not found, making a new one.".white());
-            return Self::default();
+            return Self::new();
         }
+    }
+}
+
+impl RoomExportCache {
+    /// Create a new, empty export cache.
+    pub fn new() -> Self {
+        Self {
+            room_id: None,
+            last_token: None,
+            display_name: None,
+        }
+    }
+
+    pub fn last_token(&self) -> Option<&String> {
+        self.last_token.as_ref()
+    }
+
+    pub fn room_id(&self) -> Option<&OwnedRoomId> {
+        self.room_id.as_ref()
+    }
+
+    pub fn display_name(&self) -> Option<&String> {
+        self.display_name.as_ref()
+    }
+
+    pub fn set_token(&mut self, token: String) -> anyhow::Result<()> {
+        self.last_token.replace(token);
+        anyhow::Ok(())
+    }
+
+    pub fn add_to_global(&self, global: &ExportCache) {
+        global.add_room(self.to_owned());
+    }
+
+    /// Add room data to the cache.
+    pub fn add_room_data(
+        &mut self,
+        room_id: OwnedRoomId,
+        display_name: String,
+        last_token: Option<String>,
+    ) -> &Self {
+        self.room_id.replace(room_id);
+        self.display_name.replace(display_name);
+        if let Some(token) = last_token {
+            self.last_token.replace(token);
+        }
+
+        &*self
+    }
+
+    /// Update the token of this room through a channel
+    ///
+    /// This should be used inside a background task.
+    pub async fn update_token(
+        &self,
+        mut new_token: Receiver<String>,
+        cache: &ExportCache,
+    ) -> anyhow::Result<()> {
+        while let Some(token) = new_token.recv().await {
+            stdout().execute(cursor::MoveDown(2))?;
+            println!(
+                "(cache) {}: Saving token {}",
+                self.display_name().unwrap(),
+                token
+            );
+
+            stdout().execute(cursor::RestorePosition)?;
+
+            cache.update_room_token(self.room_id().unwrap(), token)?;
+            cache.write_cache()?;
+        }
+
+        anyhow::Ok(())
     }
 }
 

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -14,9 +14,21 @@ use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
 
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
+use crate::utils::cache::{self, RoomExportCache, CACHE_INTERVAL};
+
 /// Fetch message chunks and send to a receiver
-async fn fetch_chunks(room: Room, tx: mpsc::Sender<Vec<TimelineEvent>>) -> anyhow::Result<()> {
+async fn fetch_chunks(
+    room: Room,
+    msg_tx: mpsc::Sender<Vec<TimelineEvent>>,
+    mut cache: RoomExportCache
+) -> anyhow::Result<()> {
     let mut options = MessagesOptions::backward();
+    // Load a cached token, if one exists
+    if let Some(token) = cache.last_token() {
+        println!("{}", "Last message token found in cache, resuming from it instead.".green().italic());
+        options = options.from(token.as_str());
+    }
+
     let mut total = 0;
     // make name pwetty
     let name = room
@@ -26,6 +38,17 @@ async fn fetch_chunks(room: Room, tx: mpsc::Sender<Vec<TimelineEvent>>) -> anyho
         .bold()
         .white();
 
+    let (cache_tx, cache_rx) = mpsc::channel::<String>(1);
+    cache.add_room_data(room.room_id().to_owned(), None);
+
+    // Background task, waits time, receives the last token from the main loop
+    // and sends it to the cache file.
+    tokio::spawn(async move {
+        cache.update_token(cache_rx).await
+    });
+
+    // This is used for caching.
+    let mut curr_chunk: u64 = 0;
     loop {
         stdout().execute(cursor::SavePosition)?;
         // 100 is the max (or so it seems)
@@ -35,6 +58,7 @@ async fn fetch_chunks(room: Room, tx: mpsc::Sender<Vec<TimelineEvent>>) -> anyho
         let chunk = page.chunk;
 
         total += chunk.len();
+        curr_chunk += 1;
         println!(
             "{}: Fetched {} messages (total: {})",
             name,
@@ -43,13 +67,18 @@ async fn fetch_chunks(room: Room, tx: mpsc::Sender<Vec<TimelineEvent>>) -> anyho
         );
         stdout().execute(cursor::RestorePosition)?;
 
-        if let Err(_) = tx.send(chunk).await {
+        if let Err(_) = msg_tx.send(chunk).await {
             break;
         }
 
         let Some(token) = page.end else {
             break;
         };
+
+        // Run cache, currently every 10.000 messages.
+        if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
+            cache_tx.send(token.clone()).await?;
+        }
 
         options = MessagesOptions::backward().from(&*token);
     }
@@ -66,9 +95,10 @@ pub async fn export_room(room: Room) -> anyhow::Result<()> {
     // channel to download messages and write to file
     // before, it fetched everything to memory *then* wrote, not good.
     let (tx, mut rx) = mpsc::channel::<Vec<TimelineEvent>>(100);
+    let mut cache = RoomExportCache::import_cache()?;
 
     let fetch_handle = tokio::spawn(async move {
-        if let Err(e) = fetch_chunks(room, tx).await {
+        if let Err(e) = fetch_chunks(room, tx, cache).await {
             eprintln!("Couldn't fetch events: {}", e);
             return;
         }

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -2,29 +2,26 @@ use std::io::stdout;
 
 use matrix_sdk::{
     Room,
-    deserialized_responses::{TimelineEvent, TimelineEventKind},
+    deserialized_responses::TimelineEvent,
     room::MessagesOptions,
 };
-use matrix_sdk::{
-    ruma,
-    ruma::events::{MessageLikeEvent, room::message::RoomMessageEvent},
-};
+use matrix_sdk::ruma;
 
-use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
+use tokio::{fs::OpenOptions, io::{AsyncWriteExt, BufWriter}, sync::mpsc};
 
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
-use crate::utils::cache::{CACHE_INTERVAL, RoomExportCache};
+use crate::utils::cache::{output_cache::{self}, user_cache};
 
 /// Fetch message chunks and send to a receiver
 async fn fetch_chunks(
     room: Room,
-    msg_tx: mpsc::Sender<Vec<TimelineEvent>>,
-    mut cache: RoomExportCache,
+    mut user_cache: user_cache::RoomExportCache,
+    mut out_cache: output_cache::FileCache,
 ) -> anyhow::Result<()> {
     let mut options = MessagesOptions::backward();
     // Load a cached token, if one exists
-    if let Some(token) = cache.last_token() {
+    if let Some(token) = user_cache.last_token() {
         println!(
             "{}",
             "Last message token found in cache, resuming from it instead."
@@ -43,11 +40,17 @@ async fn fetch_chunks(
         .bold()
         .white();
 
-    let (cache_tx, cache_rx) = mpsc::channel::<String>(1);
+    let (msg_tx, msg_rx) = mpsc::channel::<Vec<TimelineEvent>>(100);
+    let (user_cache_tx, user_cache_rx) = mpsc::channel::<String>(1);
+    let (write_tx, write_rx) = mpsc::channel::<bool>(1);
 
-    // Background task for caching. It receives the last token from the main loop
-    // and sends it to the cache file.
-    tokio::spawn(async move { cache.update_token(cache_rx).await });
+    // Background tasks for caching a token and the output itself.
+    tokio::spawn(async move {
+        user_cache.update_token(user_cache_rx).await
+    });
+    tokio::spawn(async move {
+        out_cache.update_messages(msg_rx, write_rx).await
+    });
 
     // This is used for caching.
     let mut curr_chunk: u64 = 0;
@@ -78,8 +81,9 @@ async fn fetch_chunks(
         };
 
         // Run cache, currently every 10.000 messages.
-        if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
-            cache_tx.send(token.clone()).await?;
+        if curr_chunk.is_multiple_of(user_cache::CACHE_INTERVAL) {
+            user_cache_tx.send(token.clone()).await?;
+            write_tx.send(true).await?;
         }
 
         options = MessagesOptions::backward().from(&*token);
@@ -92,41 +96,29 @@ async fn fetch_chunks(
 /// Export messages to a file
 pub async fn export_room(room: Room) -> anyhow::Result<()> {
     let name = room.display_name().await?.to_string();
-    let mut file = File::create(format!("{}-export.txt", name)).await?;
+
+    // appending is used in case of a cached token we resume from.
+    let file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(format!("{}-export.txt", name))
+        .await?;
+    let mut file_buf = BufWriter::with_capacity(3_000_000, file);
 
     // channel to download messages and write to file
     // before, it fetched everything to memory *then* wrote, not good.
-    let (tx, mut rx) = mpsc::channel::<Vec<TimelineEvent>>(100);
-    let mut cache = RoomExportCache::import_cache();
-    cache.add_room_data(room.room_id().to_owned(), None);
+    let mut user_cache = user_cache::RoomExportCache::import_cache();
+    let out_cache = output_cache::FileCache::new(name.clone());
+
+    user_cache.add_room_data(room.room_id().to_owned(), None);
 
     let fetch_handle = tokio::spawn(async move {
-        if let Err(e) = fetch_chunks(room, tx, cache).await {
+        if let Err(e) = fetch_chunks(room, user_cache, out_cache).await {
             eprintln!("Couldn't fetch events: {}", e);
             return;
         }
     });
 
-    // update: this still feels icky
-    while let Some(chunk) = rx.recv().await {
-        for message in chunk {
-            if let TimelineEventKind::Decrypted(decrypted) = &message.kind {
-                if let Ok(MessageLikeEvent::Original(original)) =
-                    decrypted.event.deserialize_as::<RoomMessageEvent>()
-                {
-                    let line = format!(
-                        "{:?} — {}: {}\n",
-                        original.origin_server_ts,
-                        original.sender,
-                        original.content.body()
-                    );
-
-                    file.write_all(line.as_bytes()).await?;
-                }
-            }
-        }
-        file.flush().await?;
-    }
     fetch_handle
         .await
         .map_err(|e| anyhow::anyhow!("Fetch task failed: {}", e))?;
@@ -134,6 +126,7 @@ pub async fn export_room(room: Room) -> anyhow::Result<()> {
     println!("{}: {}", name.bold(), "Export complete".bold().italic());
 
     // extra io check
-    file.flush().await?;
+    //file.flush().await?;
+    file_buf.flush().await?;
     anyhow::Ok(())
 }

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -14,18 +14,23 @@ use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
 
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
-use crate::utils::cache::{RoomExportCache, CACHE_INTERVAL};
+use crate::utils::cache::{CACHE_INTERVAL, RoomExportCache};
 
 /// Fetch message chunks and send to a receiver
 async fn fetch_chunks(
     room: Room,
     msg_tx: mpsc::Sender<Vec<TimelineEvent>>,
-    mut cache: RoomExportCache
+    mut cache: RoomExportCache,
 ) -> anyhow::Result<()> {
     let mut options = MessagesOptions::backward();
     // Load a cached token, if one exists
     if let Some(token) = cache.last_token() {
-        println!("{}", "Last message token found in cache, resuming from it instead.".green().italic());
+        println!(
+            "{}",
+            "Last message token found in cache, resuming from it instead."
+                .green()
+                .italic()
+        );
         options = options.from(token.as_str());
     }
 
@@ -42,9 +47,7 @@ async fn fetch_chunks(
 
     // Background task for caching. It receives the last token from the main loop
     // and sends it to the cache file.
-    tokio::spawn(async move {
-        cache.update_token(cache_rx).await
-    });
+    tokio::spawn(async move { cache.update_token(cache_rx).await });
 
     // This is used for caching.
     let mut curr_chunk: u64 = 0;

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -14,7 +14,7 @@ use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
 
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
-use crate::utils::cache::{self, RoomExportCache, CACHE_INTERVAL};
+use crate::utils::cache::{RoomExportCache, CACHE_INTERVAL};
 
 /// Fetch message chunks and send to a receiver
 async fn fetch_chunks(
@@ -39,9 +39,8 @@ async fn fetch_chunks(
         .white();
 
     let (cache_tx, cache_rx) = mpsc::channel::<String>(1);
-    cache.add_room_data(room.room_id().to_owned(), None);
 
-    // Background task, waits time, receives the last token from the main loop
+    // Background task for caching. It receives the last token from the main loop
     // and sends it to the cache file.
     tokio::spawn(async move {
         cache.update_token(cache_rx).await
@@ -95,7 +94,8 @@ pub async fn export_room(room: Room) -> anyhow::Result<()> {
     // channel to download messages and write to file
     // before, it fetched everything to memory *then* wrote, not good.
     let (tx, mut rx) = mpsc::channel::<Vec<TimelineEvent>>(100);
-    let mut cache = RoomExportCache::import_cache()?;
+    let mut cache = RoomExportCache::import_cache();
+    cache.add_room_data(room.room_id().to_owned(), None);
 
     let fetch_handle = tokio::spawn(async move {
         if let Err(e) = fetch_chunks(room, tx, cache).await {

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -1,17 +1,16 @@
 use std::io::stdout;
 
-use matrix_sdk::{
-    Room,
-    deserialized_responses::TimelineEvent,
-    room::MessagesOptions,
-};
 use matrix_sdk::ruma;
+use matrix_sdk::{Room, deserialized_responses::TimelineEvent, room::MessagesOptions};
 
-use tokio::{fs::OpenOptions, io::{AsyncWriteExt, BufWriter}, sync::mpsc};
+use tokio::sync::mpsc;
 
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
-use crate::utils::cache::{output_cache::{self}, user_cache};
+use crate::utils::cache::{
+    output_cache::{self},
+    user_cache,
+};
 
 /// Fetch message chunks and send to a receiver
 async fn fetch_chunks(
@@ -45,12 +44,8 @@ async fn fetch_chunks(
     let (write_tx, write_rx) = mpsc::channel::<bool>(1);
 
     // Background tasks for caching a token and the output itself.
-    tokio::spawn(async move {
-        user_cache.update_token(user_cache_rx).await
-    });
-    tokio::spawn(async move {
-        out_cache.update_messages(msg_rx, write_rx).await
-    });
+    tokio::spawn(async move { user_cache.update_token(user_cache_rx).await });
+    tokio::spawn(async move { out_cache.update_messages(msg_rx, write_rx).await });
 
     // This is used for caching.
     let mut curr_chunk: u64 = 0;
@@ -97,16 +92,6 @@ async fn fetch_chunks(
 pub async fn export_room(room: Room) -> anyhow::Result<()> {
     let name = room.display_name().await?.to_string();
 
-    // appending is used in case of a cached token we resume from.
-    let file = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(format!("{}-export.txt", name))
-        .await?;
-    let mut file_buf = BufWriter::with_capacity(3_000_000, file);
-
-    // channel to download messages and write to file
-    // before, it fetched everything to memory *then* wrote, not good.
     let mut user_cache = user_cache::RoomExportCache::import_cache();
     let out_cache = output_cache::FileCache::new(name.clone());
 
@@ -124,9 +109,5 @@ pub async fn export_room(room: Room) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Fetch task failed: {}", e))?;
 
     println!("{}: {}", name.bold(), "Export complete".bold().italic());
-
-    // extra io check
-    //file.flush().await?;
-    file_buf.flush().await?;
     anyhow::Ok(())
 }

--- a/src/utils/export.rs
+++ b/src/utils/export.rs
@@ -1,6 +1,6 @@
 use std::io::stdout;
 
-use matrix_sdk::ruma;
+use matrix_sdk::ruma::UInt;
 use matrix_sdk::{Room, deserialized_responses::TimelineEvent, room::MessagesOptions};
 
 use tokio::sync::mpsc;
@@ -8,19 +8,49 @@ use tokio::sync::mpsc;
 use promkit::crossterm::{ExecutableCommand, cursor, style::Stylize};
 
 use crate::utils::cache::{
+    CACHE_INTERVAL,
     output_cache::{self},
-    user_cache,
+    user_cache::{CACHE_DONE, ExportCache, RoomExportCache},
 };
+
+/// Convenience function, returns either a clone of the cached room, or a new one.
+/// If it's a new one, it gets added to the cache.
+fn get_room(cache: &ExportCache, room: &Room) -> RoomExportCache {
+    let room_id = room.room_id().to_owned();
+    let name = room.cached_display_name().unwrap().to_string();
+
+    if let Some(room) = cache
+        .get_inner()
+        .unwrap()
+        .rooms
+        .iter()
+        .find(|cached| cached.room_id().unwrap() == &room_id)
+    {
+        return room.clone();
+    } else {
+        let mut room = RoomExportCache::default();
+        room.add_room_data(room_id, name, None).add_to_global(cache);
+
+        return room;
+    }
+}
 
 /// Fetch message chunks and send to a receiver
 async fn fetch_chunks(
     room: Room,
-    mut user_cache: user_cache::RoomExportCache,
+    cache: &ExportCache,
     mut out_cache: output_cache::FileCache,
 ) -> anyhow::Result<()> {
     let mut options = MessagesOptions::backward();
+
+    let room_cache = get_room(cache, &room);
+
     // Load a cached token, if one exists
-    if let Some(token) = user_cache.last_token() {
+    if let Some(token) = room_cache.last_token() {
+        if token == CACHE_DONE {
+            return Err(anyhow::anyhow!("This export is marked as completed."));
+        }
+
         println!(
             "{}",
             "Last message token found in cache, resuming from it instead."
@@ -30,7 +60,6 @@ async fn fetch_chunks(
         options = options.from(token.as_str());
     }
 
-    let mut total = 0;
     // make name pwetty
     let name = room
         .cached_display_name()
@@ -40,19 +69,27 @@ async fn fetch_chunks(
         .white();
 
     let (msg_tx, msg_rx) = mpsc::channel::<Vec<TimelineEvent>>(100);
-    let (user_cache_tx, user_cache_rx) = mpsc::channel::<String>(1);
+    let (room_cache_tx, room_cache_rx) = mpsc::channel::<String>(1);
     let (write_tx, write_rx) = mpsc::channel::<bool>(1);
 
     // Background tasks for caching a token and the output itself.
-    tokio::spawn(async move { user_cache.update_token(user_cache_rx).await });
-    tokio::spawn(async move { out_cache.update_messages(msg_rx, write_rx).await });
+    let cache = cache.clone();
+    #[rustfmt::skip]
+    tokio::spawn(async move {
+        room_cache.update_token(room_cache_rx, &cache).await
+    });
+    #[rustfmt::skip]
+    tokio::spawn(async move {
+        out_cache.update_messages(msg_rx, write_rx).await
+    });
 
-    // This is used for caching.
+    // This is used for caching (and the other to let user know progress).
     let mut curr_chunk: u64 = 0;
+    let mut total = 0;
     loop {
         stdout().execute(cursor::SavePosition)?;
         // 100 is the max (or so it seems)
-        options.limit = ruma::UInt::from(100u8);
+        options.limit = UInt::from(100u8);
 
         let page = room.messages(options).await?;
         let chunk = page.chunk;
@@ -71,17 +108,20 @@ async fn fetch_chunks(
             break;
         }
 
-        let Some(token) = page.end else {
-            break;
-        };
+        if let Some(token) = page.end {
+            if curr_chunk.is_multiple_of(CACHE_INTERVAL) {
+                room_cache_tx.send(token.clone()).await?;
+                write_tx.send(true).await?;
+            }
 
-        // Run cache, currently every 10.000 messages.
-        if curr_chunk.is_multiple_of(user_cache::CACHE_INTERVAL) {
-            user_cache_tx.send(token.clone()).await?;
+            options = MessagesOptions::backward().from(&*token);
+            continue;
+        } else {
+            // on shorter exports below interval (or done ones), there's no point setting a real token.
+            room_cache_tx.send(CACHE_DONE.to_string()).await?;
             write_tx.send(true).await?;
+            break;
         }
-
-        options = MessagesOptions::backward().from(&*token);
     }
 
     println!("{}: {}", name, "Fetched all messages".green().italic());
@@ -89,16 +129,13 @@ async fn fetch_chunks(
 }
 
 /// Export messages to a file
-pub async fn export_room(room: Room) -> anyhow::Result<()> {
+pub async fn export_room(room: Room, cache: ExportCache) -> anyhow::Result<()> {
     let name = room.display_name().await?.to_string();
 
-    let mut user_cache = user_cache::RoomExportCache::import_cache();
     let out_cache = output_cache::FileCache::new(name.clone());
 
-    user_cache.add_room_data(room.room_id().to_owned(), None);
-
     let fetch_handle = tokio::spawn(async move {
-        if let Err(e) = fetch_chunks(room, user_cache, out_cache).await {
+        if let Err(e) = fetch_chunks(room, &cache, out_cache).await {
             eprintln!("Couldn't fetch events: {}", e);
             return;
         }


### PR DESCRIPTION
Not fully finished yet, need to change how files are written.

Considering this: https://github.com/kir68k/matrix-export-tool/blob/4a5b7b18d789364946addff95dfc023ec153f01f/src/utils/export.rs#L78-L81
I think it might be better sending to the file if:
- There's no pagination token (short exports)*
- OR the cache interval is hit (long exports)

Instead of doing it every chunk. So 10k messages into memory, then write to both files.

\* short export here is defined as one that doesn't require caching, i.e. under 10k.